### PR TITLE
Feature - Better exception building

### DIFF
--- a/src/Paulus/Controller/AbstractController.php
+++ b/src/Paulus/Controller/AbstractController.php
@@ -211,7 +211,7 @@ abstract class AbstractController implements ControllerInterface
     {
         // Let's turn PDO database exceptions into 502's
         if ($e instanceof \PDOException) {
-            throw BadGateway::create(null, null, $e);
+            $e = BadGateway::create(null, null, $e);
         }
 
         // Handle it with our app's default handler

--- a/src/Paulus/Controller/AbstractController.php
+++ b/src/Paulus/Controller/AbstractController.php
@@ -17,6 +17,7 @@ use Klein\Request;
 use Klein\ServiceProvider;
 use Paulus\Exception\Http\InvalidParameters;
 use Paulus\Exception\Http\ObjectNotFound;
+use Paulus\Exception\Http\Standard\BadGateway;
 use Paulus\Paulus;
 use Paulus\Response\ApiResponse;
 use Paulus\Router;
@@ -210,11 +211,7 @@ abstract class AbstractController implements ControllerInterface
     {
         // Let's turn PDO database exceptions into 502's
         if ($e instanceof \PDOException) {
-            throw new BadGateway(
-                $e->getMessage(),
-                $e->getCode(),
-                $e
-            );
+            throw BadGateway::create(null, null, $e);
         }
 
         // Handle it with our app's default handler

--- a/src/Paulus/Exception/AlreadyPreparedException.php
+++ b/src/Paulus/Exception/AlreadyPreparedException.php
@@ -27,8 +27,26 @@ class AlreadyPreparedException extends LogicException implements PaulusException
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'Paulus has already been prepared';
+
+
+    /**
      * Properties
      */
 
-    protected $message = 'Paulus has already been prepared';
+    /**
+     * The exception message
+     *
+     * @var string
+     * @access protected
+     */
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/Paulus/Exception/Http/ApiExceptionInterface.php
+++ b/src/Paulus/Exception/Http/ApiExceptionInterface.php
@@ -11,6 +11,7 @@
 
 namespace Paulus\Exception\Http;
 
+use Exception;
 use Paulus\Exception\PaulusExceptionInterface;
 
 /**
@@ -24,6 +25,37 @@ use Paulus\Exception\PaulusExceptionInterface;
  */
 interface ApiExceptionInterface extends PaulusExceptionInterface
 {
+
+    /**
+     * Static creation method designed to allow for easier fall-back to default
+     * values than the default exception constructor
+     *
+     * @param string $message
+     * @param int $code
+     * @param Exception $previous
+     * @static
+     * @access public
+     * @return ApiExceptionInterface
+     */
+    public static function create($message = null, $code = null, Exception $previous = null);
+
+    /**
+     * Get the default message for this type of exception
+     *
+     * @static
+     * @access public
+     * @return string
+     */
+    public static function getDefaultMessage();
+
+    /**
+     * Get the default code for this type of exception
+     *
+     * @static
+     * @access public
+     * @return int
+     */
+    public static function getDefaultCode();
 
     /**
      * Get the slug

--- a/src/Paulus/Exception/Http/ApiExceptionTrait.php
+++ b/src/Paulus/Exception/Http/ApiExceptionTrait.php
@@ -11,6 +11,8 @@
 
 namespace Paulus\Exception\Http;
 
+use Exception;
+
 /**
  * ApiExceptionTrait
  *

--- a/src/Paulus/Exception/Http/ApiExceptionTrait.php
+++ b/src/Paulus/Exception/Http/ApiExceptionTrait.php
@@ -40,6 +40,65 @@ trait ApiExceptionTrait
      */
 
     /**
+     * Static creation method designed to allow for easier fall-back to default
+     * values than the default exception constructor
+     *
+     * @param string $message
+     * @param int $code
+     * @param Exception $previous
+     * @static
+     * @access public
+     * @return ApiExceptionInterface
+     */
+    public static function create($message = null, $code = null, Exception $previous = null)
+    {
+        $message = (null !== $message) ? $message : static::getDefaultMessage();
+        $code = (null !== $code) ? $code : static::getDefaultCode();
+
+        return new static($message, $code, $previous);
+    }
+
+    /**
+     * Get the default message for this type of exception
+     *
+     * @static
+     * @access public
+     * @return string
+     */
+    public static function getDefaultMessage()
+    {
+        $default_message_constant = 'static::DEFAULT_MESSAGE';
+
+        if (defined($default_message_constant)) {
+            return (string) constant($default_message_constant);
+        } else {
+            trigger_error('Class constant DEFAULT_MESSAGE not defined', E_USER_NOTICE);
+        }
+
+        return '';
+    }
+
+    /**
+     * Get the default code for this type of exception
+     *
+     * @static
+     * @access public
+     * @return int
+     */
+    public static function getDefaultCode()
+    {
+        $default_code_constant = 'static::DEFAULT_CODE';
+
+        if (defined($default_code_constant)) {
+            return (int) constant($default_code_constant);
+        } else {
+            trigger_error('Class constant DEFAULT_CODE not defined', E_USER_NOTICE);
+        }
+
+        return 0;
+    }
+
+    /**
      * Get the slug
      *
      * @access public

--- a/src/Paulus/Exception/Http/EndpointNotFound.php
+++ b/src/Paulus/Exception/Http/EndpointNotFound.php
@@ -26,10 +26,26 @@ class EndpointNotFound extends NotFound
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'Unable to find the endpoint you requested';
+
+
+    /**
+     * Properties
+     */
+
+    /**
      * The exception message
      *
      * @var string
      * @access protected
      */
-    protected $message = 'Unable to find the endpoint you requested';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/Paulus/Exception/Http/ForbiddenResource.php
+++ b/src/Paulus/Exception/Http/ForbiddenResource.php
@@ -26,10 +26,26 @@ class ForbiddenResource extends Forbidden
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'You are forbidden to access or modify this';
+
+
+    /**
+     * Properties
+     */
+
+    /**
      * The exception message
      *
      * @var string
      * @access protected
      */
-    protected $message = 'You are forbidden to access or modify this';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/Paulus/Exception/Http/InvalidParameters.php
+++ b/src/Paulus/Exception/Http/InvalidParameters.php
@@ -34,6 +34,25 @@ class InvalidParameters extends BadRequest implements ApiVerboseExceptionInterfa
 
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception slug
+     *
+     * @const string
+     */
+    const DEFAULT_SLUG = 'INVALID_PARAMETERS';
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'The posted data did not pass validation';
+
+
+    /**
      * Properties
      */
 
@@ -43,7 +62,7 @@ class InvalidParameters extends BadRequest implements ApiVerboseExceptionInterfa
      * @var string
      * @access protected
      */
-    protected $slug = 'INVALID_PARAMETERS';
+    protected $slug = self::DEFAULT_SLUG;
 
     /**
      * The exception message
@@ -51,5 +70,5 @@ class InvalidParameters extends BadRequest implements ApiVerboseExceptionInterfa
      * @var string
      * @access protected
      */
-    protected $message = 'The posted data did not pass validation';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/Paulus/Exception/Http/InvalidRequestSyntax.php
+++ b/src/Paulus/Exception/Http/InvalidRequestSyntax.php
@@ -27,12 +27,35 @@ class InvalidRequestSyntax extends BadRequest
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception slug
+     *
+     * @const string
+     */
+    const DEFAULT_SLUG = 'INVALID_REQUEST_SYNTAX';
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'The posted request\'s syntax is invalid';
+
+
+    /**
+     * Properties
+     */
+
+    /**
      * The exception slug
      *
      * @var string
      * @access protected
      */
-    protected $slug = 'INVALID_REQUEST_SYNTAX';
+    protected $slug = self::DEFAULT_SLUG;
 
     /**
      * The exception message
@@ -40,5 +63,5 @@ class InvalidRequestSyntax extends BadRequest
      * @var string
      * @access protected
      */
-    protected $message = 'The posted request\'s syntax is invalid';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/Paulus/Exception/Http/ObjectNotFound.php
+++ b/src/Paulus/Exception/Http/ObjectNotFound.php
@@ -26,10 +26,26 @@ class ObjectNotFound extends NotFound
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'Object does not exist';
+
+
+    /**
+     * Properties
+     */
+
+    /**
      * The exception message
      *
      * @var string
      * @access protected
      */
-    protected $message = 'Object does not exist';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/Paulus/Exception/Http/Standard/BadGateway.php
+++ b/src/Paulus/Exception/Http/Standard/BadGateway.php
@@ -36,6 +36,25 @@ class BadGateway extends RuntimeException implements ApiExceptionInterface
 
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = '';
+
+    /**
+     * The default exception code
+     *
+     * @const int
+     */
+    const DEFAULT_CODE = 502;
+
+
+    /**
      * Properties
      */
 
@@ -45,5 +64,5 @@ class BadGateway extends RuntimeException implements ApiExceptionInterface
      * @var int
      * @access protected
      */
-    protected $code = 502;
+    protected $code = self::DEFAULT_CODE;
 }

--- a/src/Paulus/Exception/Http/Standard/BadRequest.php
+++ b/src/Paulus/Exception/Http/Standard/BadRequest.php
@@ -36,6 +36,25 @@ class BadRequest extends UnexpectedValueException implements ApiExceptionInterfa
 
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = '';
+
+    /**
+     * The default exception code
+     *
+     * @const int
+     */
+    const DEFAULT_CODE = 400;
+
+
+    /**
      * Properties
      */
 
@@ -45,5 +64,5 @@ class BadRequest extends UnexpectedValueException implements ApiExceptionInterfa
      * @var int
      * @access protected
      */
-    protected $code = 400;
+    protected $code = self::DEFAULT_CODE;
 }

--- a/src/Paulus/Exception/Http/Standard/Forbidden.php
+++ b/src/Paulus/Exception/Http/Standard/Forbidden.php
@@ -36,6 +36,25 @@ class Forbidden extends OutOfBoundsException implements ApiExceptionInterface
 
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = '';
+
+    /**
+     * The default exception code
+     *
+     * @const int
+     */
+    const DEFAULT_CODE = 403;
+
+
+    /**
      * Properties
      */
 
@@ -45,5 +64,5 @@ class Forbidden extends OutOfBoundsException implements ApiExceptionInterface
      * @var int
      * @access protected
      */
-    protected $code = 403;
+    protected $code = self::DEFAULT_CODE;
 }

--- a/src/Paulus/Exception/Http/Standard/InternalServerError.php
+++ b/src/Paulus/Exception/Http/Standard/InternalServerError.php
@@ -36,6 +36,25 @@ class InternalServerError extends RuntimeException implements ApiExceptionInterf
 
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = '';
+
+    /**
+     * The default exception code
+     *
+     * @const int
+     */
+    const DEFAULT_CODE = 500;
+
+
+    /**
      * Properties
      */
 
@@ -45,5 +64,5 @@ class InternalServerError extends RuntimeException implements ApiExceptionInterf
      * @var int
      * @access protected
      */
-    protected $code = 500;
+    protected $code = self::DEFAULT_CODE;
 }

--- a/src/Paulus/Exception/Http/Standard/MethodNotAllowed.php
+++ b/src/Paulus/Exception/Http/Standard/MethodNotAllowed.php
@@ -36,6 +36,25 @@ class MethodNotAllowed extends OutOfBoundsException implements ApiExceptionInter
 
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = '';
+
+    /**
+     * The default exception code
+     *
+     * @const int
+     */
+    const DEFAULT_CODE = 405;
+
+
+    /**
      * Properties
      */
 
@@ -45,5 +64,5 @@ class MethodNotAllowed extends OutOfBoundsException implements ApiExceptionInter
      * @var int
      * @access protected
      */
-    protected $code = 405;
+    protected $code = self::DEFAULT_CODE;
 }

--- a/src/Paulus/Exception/Http/Standard/NotAcceptable.php
+++ b/src/Paulus/Exception/Http/Standard/NotAcceptable.php
@@ -36,6 +36,25 @@ class NotAcceptable extends UnexpectedValueException implements ApiExceptionInte
 
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = '';
+
+    /**
+     * The default exception code
+     *
+     * @const int
+     */
+    const DEFAULT_CODE = 406;
+
+
+    /**
      * Properties
      */
 
@@ -45,5 +64,5 @@ class NotAcceptable extends UnexpectedValueException implements ApiExceptionInte
      * @var int
      * @access protected
      */
-    protected $code = 406;
+    protected $code = self::DEFAULT_CODE;
 }

--- a/src/Paulus/Exception/Http/Standard/NotFound.php
+++ b/src/Paulus/Exception/Http/Standard/NotFound.php
@@ -36,6 +36,25 @@ class NotFound extends OutOfBoundsException implements ApiExceptionInterface
 
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = '';
+
+    /**
+     * The default exception code
+     *
+     * @const int
+     */
+    const DEFAULT_CODE = 404;
+
+
+    /**
      * Properties
      */
 
@@ -45,5 +64,5 @@ class NotFound extends OutOfBoundsException implements ApiExceptionInterface
      * @var int
      * @access protected
      */
-    protected $code = 404;
+    protected $code = self::DEFAULT_CODE;
 }

--- a/src/Paulus/Exception/Http/Standard/NotImplemented.php
+++ b/src/Paulus/Exception/Http/Standard/NotImplemented.php
@@ -36,6 +36,25 @@ class NotImplemented extends RuntimeException implements ApiExceptionInterface
 
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = '';
+
+    /**
+     * The default exception code
+     *
+     * @const int
+     */
+    const DEFAULT_CODE = 501;
+
+
+    /**
      * Properties
      */
 
@@ -45,5 +64,5 @@ class NotImplemented extends RuntimeException implements ApiExceptionInterface
      * @var int
      * @access protected
      */
-    protected $code = 501;
+    protected $code = self::DEFAULT_CODE;
 }

--- a/src/Paulus/Exception/Http/Standard/Unauthorized.php
+++ b/src/Paulus/Exception/Http/Standard/Unauthorized.php
@@ -36,6 +36,25 @@ class Unauthorized extends InvalidArgumentException implements ApiExceptionInter
 
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = '';
+
+    /**
+     * The default exception code
+     *
+     * @const int
+     */
+    const DEFAULT_CODE = 401;
+
+
+    /**
      * Properties
      */
 
@@ -45,5 +64,5 @@ class Unauthorized extends InvalidArgumentException implements ApiExceptionInter
      * @var int
      * @access protected
      */
-    protected $code = 401;
+    protected $code = self::DEFAULT_CODE;
 }

--- a/src/Paulus/Exception/Http/UnauthorizedAccess.php
+++ b/src/Paulus/Exception/Http/UnauthorizedAccess.php
@@ -26,10 +26,26 @@ class UnauthorizedAccess extends Unauthorized
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'You are not authorized to access or modify this';
+
+
+    /**
+     * Properties
+     */
+
+    /**
      * The exception message
      *
      * @var string
      * @access protected
      */
-    protected $message = 'You are not authorized to access or modify this';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/Paulus/Exception/Http/WrongMethod.php
+++ b/src/Paulus/Exception/Http/WrongMethod.php
@@ -34,6 +34,18 @@ class WrongMethod extends MethodNotAllowed implements ApiVerboseExceptionInterfa
 
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'The wrong method was called on this endpoint';
+
+
+    /**
      * Properties
      */
 
@@ -43,5 +55,5 @@ class WrongMethod extends MethodNotAllowed implements ApiVerboseExceptionInterfa
      * @var string
      * @access protected
      */
-    protected $message = 'The wrong method was called on this endpoint';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/Paulus/Exception/RouteAutoLoadFailureException.php
+++ b/src/Paulus/Exception/RouteAutoLoadFailureException.php
@@ -26,8 +26,26 @@ class RouteAutoLoadFailureException extends UnexpectedValueException implements 
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'Unable to load routes automatically';
+
+
+    /**
      * Properties
      */
 
-    protected $message = 'Unable to load routes automatically';
+    /**
+     * The exception message
+     *
+     * @var string
+     * @access protected
+     */
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/Paulus/Exception/UnableToInferRouteDirectoryException.php
+++ b/src/Paulus/Exception/UnableToInferRouteDirectoryException.php
@@ -24,10 +24,28 @@ class UnableToInferRouteDirectoryException extends RouteAutoLoadFailureException
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'Unable to infer route directory.
+        Please provide a RouteLoader instance
+        with a valid path to the `prepare()` method.';
+
+
+    /**
      * Properties
      */
 
-    protected $message = 'Unable to infer route directory.
-        Please provide a RouteLoader instance
-        with a valid path to the `prepare()` method.';
+    /**
+     * The exception message
+     *
+     * @var string
+     * @access protected
+     */
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/Paulus/Logger/BasicLogger.php
+++ b/src/Paulus/Logger/BasicLogger.php
@@ -40,13 +40,39 @@ class BasicLogger extends AbstractLogger implements LoggerInterface
 
         // If we have an exception...
         if (isset($context['exception']) && $context['exception'] instanceof Exception) {
-            // Add to the formatted string
-            $formatted .= sprintf(
-                PHP_EOL.PHP_EOL. 'Exception "%s" (code %d) thrown with trace:"%s"',
-                get_class($context['exception']),
-                $context['exception']->getCode(),
-                PHP_EOL.PHP_EOL. $context['exception']->getTraceAsString()
-            );
+            $exception = $context['exception'];
+            $first = true;
+
+            // Loop through the previous exceptions
+            while (null !== $exception) {
+                // Line padding
+                $formatted .= PHP_EOL.PHP_EOL;
+
+                if (!$first) {
+                    $formatted .= 'Caused by:' .PHP_EOL;
+                } else {
+                    $first = false;
+                }
+
+                // Format a string of exception origin
+                $origin = sprintf(
+                    'Origin: %s(%d)',
+                    $exception->getFile(),
+                    $exception->getLine()
+                );
+
+                // Add to the formatted string
+                $formatted .= sprintf(
+                    'Exception "%s" (code %d) thrown with trace:"%s%s"',
+                    get_class($exception),
+                    $exception->getCode(),
+                    PHP_EOL.PHP_EOL. $origin,
+                    PHP_EOL. $exception->getTraceAsString()
+                );
+
+                // Grab the previous one
+                $exception = $exception->getPrevious();
+            };
         }
 
         return $formatted;


### PR DESCRIPTION
This PR changes Paulus 2's style of creating and handling of exceptions.

First of all, instead of just providing default `$message` or `$code` properties, we provide publicly available constants. This does a few things:
- External libraries can create exceptions using the messages defined in the constants
- The constants are statically compiled (all the better for opcaching)
- The values are always available, instead of having to first instantiate the exception first

Not only that, but this allows us to pass previous exceptions down the chain easier using the newly implemented static `create()` method. See, by default, the [`Exception::__construct()`](http://php.net/manual/en/exception.construct.php) method takes a few optional parameters. PHP doesn't have any way of "skipping" parameters, so if you wanted to instantiate an exception with its default message and code but with a passed in `$previous` value, you couldn't without nullifying the message and code (therefore removing the default messages). The new create method along with the publicly and statically available constants allows this entire process to work.

So previously:

![screen shot 2014-09-04 at 5 09 55 pm](https://cloud.githubusercontent.com/assets/742384/4156854/fadf26e0-3477-11e4-9ed7-44872c0dd776.png)

But now:
![screen shot 2014-09-04 at 5 10 41 pm](https://cloud.githubusercontent.com/assets/742384/4156855/ff4075c2-3477-11e4-869d-5bbd3e9d1cab.png)

This also improves our logger by making sure to now loop over our previous exceptions and log their stack traces too. Before this, we had a problem with context as to what was failing.
