### PR TITLE
Bugfix - Correctly Checking Data in Response

### DIFF
--- a/src/Paulus/Response/ApiResponse.php
+++ b/src/Paulus/Response/ApiResponse.php
@@ -227,7 +227,7 @@ class ApiResponse extends JsonResponse
         ];
 
         // Assign our data
-        $formatted->data = $this->getData() ?: (object) [];
+        $formatted->data = (null === $this->getData()) ? (object) [] : $this->getData();
 
         return $formatted;
     }

--- a/tests/Paulus/Tests/Response/ApiResponseTest.php
+++ b/tests/Paulus/Tests/Response/ApiResponseTest.php
@@ -62,10 +62,10 @@ class ApiResponseTest extends AbstractPaulusTest
         $this->assertFalse($response->isLocked());
     }
 
-    public function testGetSetData()
+    public function testGetSetData($test_data = null)
     {
         // Test data
-        $test_data = $this->getTestData();
+        $test_data = (null === $test_data) ? $this->getTestData() : $test_data;
 
         $response = new ApiResponse();
 
@@ -77,6 +77,14 @@ class ApiResponseTest extends AbstractPaulusTest
 
         $this->assertSame($test_data, $response->getData());
         $this->assertNotSame($old_body, $new_body);
+    }
+
+    public function testGetSetEmptyDataSet()
+    {
+        // Set the test data to be an empty array
+        $test_data = [];
+
+        $this->testGetSetData($test_data);
     }
 
     public function testGetSetStatusSlug()


### PR DESCRIPTION
Before the ApiResponse method was checking via a ternary, which makes use of php's [empty function](http://php.net/manual/en/function.empty.php). This causes an issue when `getData()` returns an empty array since it will just be cast to an empty stdObject. This PR fixes the issue by strictly checking if `getData()` returns `null`.

Now a client that is expecting an empty array in a response rather than an empty object during encoding won't get confused.
