### PR TITLE
Bugfix - Invalid router construction

### DIFF
--- a/src/Paulus/Router.php
+++ b/src/Paulus/Router.php
@@ -310,11 +310,11 @@ class Router extends Klein
      * @see Klein\Klein::handleRouteCallback()
      * @param Route $route
      * @param RouteCollection $matched
-     * @param mixed $methods_matched
+     * @param array $methods_matched
      * @access protected
      * @return void
      */
-    protected function handleRouteCallback(Route $route, RouteCollection $matched, $methods_matched)
+    protected function handleRouteCallback(Route $route, RouteCollection $matched, array $methods_matched)
     {
         // Get the result handler of the current controller
         $handler = $this->getControllerResultHandler();

--- a/src/Paulus/Router.php
+++ b/src/Paulus/Router.php
@@ -12,6 +12,7 @@
 namespace Paulus;
 
 use Klein\AbstractResponse;
+use Klein\AbstractRouteFactory;
 use Klein\DataCollection\RouteCollection;
 use Klein\Klein;
 use Klein\Request;
@@ -80,14 +81,16 @@ class Router extends Klein
         RouteCollection $routes = null,
         AbstractRouteFactory $route_factory = null
     ) {
-        // Instanciate and fall back to defaults
-        $this->service       = $service       ?: new ServiceProvider();
+        // Build with our parent, overriding certain injectables
+        parent::__construct(
+            null,
+            null,
+            null,
+            $route_factory ?: new RouteFactory()
+        );
 
-        $this->routes        = $routes        ?: new RouteCollection();
-        $this->route_factory = $route_factory ?: new RouteFactory();
-
-        // Ignore their app entry, always keep as null
-        $this->app           = null;
+        // Don't fallback to a default `app` instance. Keep as null if none provided
+        $this->app = $app ?: null;
     }
 
     /**

--- a/tests/Paulus/Tests/PaulusTest.php
+++ b/tests/Paulus/Tests/PaulusTest.php
@@ -91,7 +91,7 @@ class PaulusTest extends AbstractPaulusTest
     {
         $default = $this->paulus_app->getDefaultResponse();
 
-        $this->assertSame(ltrim(Paulus::FALLBACK_RESPONSE_CLASS, '\\'), get_class($default));
+        $this->assertSame(ltrim(Paulus::DEFAULT_RESPONSE_CLASS, '\\'), get_class($default));
 
         $json_response = new JsonResponse();
 

--- a/tests/Paulus/Tests/PaulusTest.php
+++ b/tests/Paulus/Tests/PaulusTest.php
@@ -14,7 +14,9 @@ namespace Paulus\Tests;
 use Klein\DataCollection\RouteCollection;
 use Paulus\DataCollection\ImmutableDataCollection;
 use Paulus\FileLoader\RouteLoaderFactory;
+use Paulus\Logger\BasicLogger;
 use Paulus\Paulus;
+use Paulus\Response\JsonResponse;
 use Paulus\Router;
 use Paulus\ServiceLocator;
 
@@ -76,6 +78,26 @@ class PaulusTest extends AbstractPaulusTest
         $locator = $this->paulus_app->locator();
 
         $this->assertTrue($locator instanceof ServiceLocator);
+    }
+
+    public function testLogger()
+    {
+        $logger = $this->paulus_app->logger();
+
+        $this->assertTrue($logger instanceof BasicLogger);
+    }
+
+    public function testGetSetDefaultResponse()
+    {
+        $default = $this->paulus_app->getDefaultResponse();
+
+        $this->assertSame(ltrim(Paulus::FALLBACK_RESPONSE_CLASS, '\\'), get_class($default));
+
+        $json_response = new JsonResponse();
+
+        $this->paulus_app->setDefaultResponse($json_response);
+
+        $this->assertSame($json_response, $this->paulus_app->getDefaultResponse());
     }
 
     public function testPrepareWithoutAutoLoading()

--- a/tests/Paulus/Tests/Response/ApiResponseTest.php
+++ b/tests/Paulus/Tests/Response/ApiResponseTest.php
@@ -51,7 +51,7 @@ class ApiResponseTest extends AbstractPaulusTest
         $test_data = $this->getTestData();
         $test_status_code = 304;
         $test_headers = [
-            'x-whatever' => 'yup',
+            'X-Whatever' => 'yup',
         ];
 
         $response = new ApiResponse($test_data, $test_status_code, $test_headers);

--- a/tests/Paulus/Tests/Response/JsonResponseTest.php
+++ b/tests/Paulus/Tests/Response/JsonResponseTest.php
@@ -51,7 +51,7 @@ class JsonResponseTest extends AbstractPaulusTest
         $test_data = $this->getTestData();
         $test_status_code = 304;
         $test_headers = [
-            'x-whatever' => 'yup',
+            'X-Whatever' => 'yup',
         ];
 
         $response = new JsonResponse($test_data, $test_status_code, $test_headers);
@@ -90,13 +90,13 @@ class JsonResponseTest extends AbstractPaulusTest
         $test_data = $this->getTestData();
         $test_status_code = 304;
         $test_headers = [
-            'content-type' => 'image/png',
+            'Content-Type' => 'image/png',
         ];
 
         $response = new JsonResponse($test_data, $test_status_code, $test_headers);
 
         $this->assertSame(
-            $test_headers['content-type'],
+            $test_headers['Content-Type'],
             $response->headers()->get('content-type')
         );
         $this->assertSame(


### PR DESCRIPTION
Uhhh, so thanks to @jstruzik running some tests locally, I was informed of some failing tests.... Oops.

This PR fixes some dumb mistakes in the `Router` class and updates some methods to work with the slightly changed protected API in Klein.
