### PR TITLE
Bugfix - Upgrading HTTP error handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
    "require": {
       "php": ">=5.4.0",
       "klein/klein": "dev-master",
-      "psr/log": "1.0.0"
+      "psr/log": "~1.0"
    },
    "require-dev": {
-      "phpunit/phpunit": "3.7.x",
-      "phpunit/php-code-coverage": "1.2.x",
-      "squizlabs/php_codesniffer": "~1.5.0"
+      "phpunit/phpunit": "~3.7",
+      "phpunit/php-code-coverage": "~1.2",
+      "squizlabs/php_codesniffer": "~1.5"
    },
    "autoload": {
       "psr-0": { "Paulus": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
    "require-dev": {
       "phpunit/phpunit": "3.7.x",
       "phpunit/php-code-coverage": "1.2.x",
-      "squizlabs/php_codesniffer": "1.4.6"
+      "squizlabs/php_codesniffer": "~1.5.0"
    },
    "autoload": {
       "psr-0": { "Paulus": "src/" }

--- a/src/Paulus/Exception/Http/WrongMethod.php
+++ b/src/Paulus/Exception/Http/WrongMethod.php
@@ -82,7 +82,7 @@ class WrongMethod extends MethodNotAllowed implements ApiVerboseExceptionInterfa
     {
         // Tell them of the possible methods
         $this->setMoreInfo([
-            static::MORE_INFO_ALLOWED_METHODS_KEY => $methods_matched,
+            static::MORE_INFO_ALLOWED_METHODS_KEY => $allowed_methods,
         ]);
 
         return $this;

--- a/src/Paulus/Exception/Http/WrongMethod.php
+++ b/src/Paulus/Exception/Http/WrongMethod.php
@@ -44,6 +44,13 @@ class WrongMethod extends MethodNotAllowed implements ApiVerboseExceptionInterfa
      */
     const DEFAULT_MESSAGE = 'The wrong method was called on this endpoint';
 
+    /**
+     * The "more_info" map key to use for notifying of the allowed methods
+     *
+     * @type string
+     */
+    const MORE_INFO_ALLOWED_METHODS_KEY = 'possible_methods';
+
 
     /**
      * Properties
@@ -56,4 +63,28 @@ class WrongMethod extends MethodNotAllowed implements ApiVerboseExceptionInterfa
      * @access protected
      */
     protected $message = self::DEFAULT_MESSAGE;
+
+
+    /**
+     * Methods
+     */
+
+    /**
+     * Set the HTTP methods that are "allowed" or possible
+     *
+     * This helps communicate to the client what methods would be correct to use
+     * when they receive this exception as an HTTP response
+     *
+     * @param array $allowed_methods
+     * @return WrongMethod
+     */
+    public function setAllowedMethods(array $allowed_methods)
+    {
+        // Tell them of the possible methods
+        $this->setMoreInfo([
+            static::MORE_INFO_ALLOWED_METHODS_KEY => $methods_matched,
+        ]);
+
+        return $this;
+    }
 }

--- a/src/Paulus/Paulus.php
+++ b/src/Paulus/Paulus.php
@@ -380,11 +380,7 @@ class Paulus
                             $exception = WrongMethod::create(null, null, $http_exception);
 
                             // Tell them of the possible methods
-                            $exception->setMoreInfo(
-                                [
-                                    'possible_methods' => $methods_matched,
-                                ]
-                            );
+                            $exception->setAllowedMethods($methods_matched);
 
                             throw $exception;
                         }

--- a/src/Paulus/Router.php
+++ b/src/Paulus/Router.php
@@ -191,47 +191,6 @@ class Router extends Klein
     }
 
     /**
-     * Setup our default error route responders
-     * by registering them with our router
-     *
-     * @access public
-     * @return Router
-     */
-    public function setupDefaultErrorRoutes()
-    {
-        // "HTTP 404 Not Found" default handler
-        $this->respond(
-            404,
-            function () {
-                throw new EndpointNotFound();
-            }
-        )->setName(404);
-
-        // "HTTP 405 Method Not Allowed" default handler
-        $this->respond(
-            405,
-            function ($request, $response, $service, $app, $router, $matched, $methods_matched) {
-                // Don't error out on an OPTIONS request
-                if (!$request->method('OPTIONS')) {
-                    $exception = new WrongMethod();
-
-                    // Tell them of the possible methods
-                    $exception->setMoreInfo(
-                        [
-                            'possible_methods' => $methods_matched,
-                        ]
-                    );
-
-                    throw $exception;
-
-                }
-            }
-        )->setName(405);
-
-        return $this;
-    }
-
-    /**
      * Get the current controller's exception handler
      * if there is one defined
      *


### PR DESCRIPTION
## HTTP error handling

This PR updates Paulus to use the newer style of HTTP error handling introduced in chriso/klein.php#16.

This is especially important since the old style of HTTP error handling has been deprecated as of chriso/klein.php#221.

---
### Composer bits

This PR also cleans up some of the composer requirements since PHP Codesniffer was yelling at me for a false-positive PSR-2 compliance issue. When I went to upgrade it, I figured I'd clean up the composer requirements to use the newly suggested style of version constraints.

This new style of version constraints is not only suggested, its now the automatic designation as of composer/composer#3096. More info on and explanation of this new suggestion can be found here:
http://blog.doh.ms/2014/10/13/installing-composer-packages/
