### PR TITLE
Feature - Updating Composer schema

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+#
+# Reduce the distributed files in a distribution-build of this library/package
+#
+
+/docs                  export-ignore
+/tests                 export-ignore
+/.gitattributes        export-ignore
+/.gitignore            export-ignore
+/.phpunit.xml.dist     export-ignore

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "klein/klein": "dev-master",
+    "klein/klein": "~2.1.0",
     "psr/log": "~1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
     "squizlabs/php_codesniffer": "~1.5"
   },
   "autoload": {
-    "psr-0": { "Paulus": "src/" }
+    "psr-4": { "Paulus\\": "src/Paulus/" }
+  },
+  "autoload-dev": {
+    "psr-4": { "Paulus\\Tests\\": "tests/Paulus/Tests" }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
       "homepage": "http://about.me/tnsuarez"
     }
   ],
+  "extra": {
+    "branch-alias": {
+      "dev-release/2.0.0": "2.0.x-dev"
+    }
+  },
   "require": {
     "php": ">=5.4.0",
     "klein/klein": "~2.1.0",

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "authors": [
     {
-    "name": "Trevor N. Suarez",
-    "email": "rican7@gmail.com",
-    "homepage": "http://about.me/tnsuarez"
-  }
+      "name": "Trevor N. Suarez",
+      "email": "rican7@gmail.com",
+      "homepage": "http://about.me/tnsuarez"
+    }
   ],
   "require": {
     "php": ">=5.4.0",

--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,27 @@
 {
-   "name": "paulus/paulus",
-   "description": "A PHP micro-framework for creating RESTful services quickly and efficiently.",
-   "keywords": ["microframework", "rest", "routing", "router", "api", "boilerplate"],
-   "homepage": "https://github.com/Rican7/Paulus",
-   "license": "MIT",
-   "authors": [
-      {
-      "name": "Trevor N. Suarez",
-      "email": "rican7@gmail.com",
-      "homepage": "http://about.me/tnsuarez"
-   }
-   ],
-   "require": {
-      "php": ">=5.4.0",
-      "klein/klein": "dev-master",
-      "psr/log": "~1.0"
-   },
-   "require-dev": {
-      "phpunit/phpunit": "~3.7",
-      "phpunit/php-code-coverage": "~1.2",
-      "squizlabs/php_codesniffer": "~1.5"
-   },
-   "autoload": {
-      "psr-0": { "Paulus": "src/" }
-   }
+  "name": "paulus/paulus",
+  "description": "A PHP micro-framework for creating RESTful services quickly and efficiently.",
+  "keywords": ["microframework", "rest", "routing", "router", "api", "boilerplate"],
+  "homepage": "https://github.com/Rican7/Paulus",
+  "license": "MIT",
+  "authors": [
+    {
+    "name": "Trevor N. Suarez",
+    "email": "rican7@gmail.com",
+    "homepage": "http://about.me/tnsuarez"
+  }
+  ],
+  "require": {
+    "php": ">=5.4.0",
+    "klein/klein": "dev-master",
+    "psr/log": "~1.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "~3.7",
+    "phpunit/php-code-coverage": "~1.2",
+    "squizlabs/php_codesniffer": "~1.5"
+  },
+  "autoload": {
+    "psr-0": { "Paulus": "src/" }
+  }
 }

--- a/tests/Paulus/Tests/Response/ApiResponseTest.php
+++ b/tests/Paulus/Tests/Response/ApiResponseTest.php
@@ -58,8 +58,14 @@ class ApiResponseTest extends AbstractPaulusTest
 
         $this->assertSame($test_data, $response->getData());
         $this->assertSame($test_status_code, $response->code());
-        $this->assertEquals($test_headers, $response->headers()->all(array_keys($test_headers)));
         $this->assertFalse($response->isLocked());
+
+        $this->assertEquals(
+            array_change_key_case($test_headers, CASE_LOWER),
+            $response->headers()->all(
+                array_keys(array_change_key_case($test_headers, CASE_LOWER))
+            )
+        );
     }
 
     public function testGetSetData($test_data = null)

--- a/tests/Paulus/Tests/Response/JsonResponseTest.php
+++ b/tests/Paulus/Tests/Response/JsonResponseTest.php
@@ -58,8 +58,14 @@ class JsonResponseTest extends AbstractPaulusTest
 
         $this->assertSame($test_data, $response->getData());
         $this->assertSame($test_status_code, $response->code());
-        $this->assertEquals($test_headers, $response->headers()->all(array_keys($test_headers)));
         $this->assertFalse($response->isLocked());
+
+        $this->assertEquals(
+            array_change_key_case($test_headers, CASE_LOWER),
+            $response->headers()->all(
+                array_keys(array_change_key_case($test_headers, CASE_LOWER))
+            )
+        );
     }
 
     public function testSetData()
@@ -99,9 +105,10 @@ class JsonResponseTest extends AbstractPaulusTest
             $test_headers['Content-Type'],
             $response->headers()->get('content-type')
         );
-        $this->assertSame(
-            $test_headers,
-            $response->headers()->all()
+
+        $this->assertEquals(
+            array_change_key_case($test_headers, CASE_LOWER),
+            array_change_key_case($response->headers()->all(), CASE_LOWER)
         );
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,6 +12,5 @@
 // Turn on all errors for our unit testing
 error_reporting(-1);
 
-// Load our autoloader, and add our Test class namespace
-$autoloader = require(__DIR__ . '/../vendor/autoload.php');
-$autoloader->add('Paulus\Tests', __DIR__);
+// Load our autoloader
+require(__DIR__ . '/../vendor/autoload.php');


### PR DESCRIPTION
This PR quickly updates the Composer schema to:
- Use PSR-4 autoloading
- Use an [`autoload-dev`](https://getcomposer.org/doc/04-schema.md#autoload-dev) section for autoloading the tests properly
- Use a 2-space indentation
- Alias the release branch for a development version number string
- Rely on a stable version of Klein! 2.1! Woot!

Since I've re-indented the `composer.json` file, here's a convenient link to look at the file diff without whitespace changes: https://github.com/Rican7/Paulus/pull/11/files?w=1
