### PR TITLE
Feature - API exception handler critical logs for server errors

### DIFF
--- a/src/Paulus/Handler/Exception/RestfulExceptionHandler.php
+++ b/src/Paulus/Handler/Exception/RestfulExceptionHandler.php
@@ -17,6 +17,7 @@ use Klein\HttpStatus;
 use Paulus\Exception\Http\ApiExceptionInterface;
 use Paulus\Exception\Http\ApiVerboseExceptionInterface;
 use Paulus\Support\Inflector;
+use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/src/Paulus/Handler/Exception/RestfulExceptionHandler.php
+++ b/src/Paulus/Handler/Exception/RestfulExceptionHandler.php
@@ -127,9 +127,10 @@ class RestfulExceptionHandler extends InformativeExceptionHandler
         $this->logInfoMessage();
 
         $log_level = LogLevel::ERROR;
+        $exception_code = (int) $exception->getCode();
 
         // If the API exception is representing a server error
-        if (500 <= $exception->getCode() && $exception->getCode() <= 599) {
+        if (500 <= $exception_code && $exception_code <= 599) {
             $log_level = LogLevel::CRITICAL;
         }
 

--- a/src/Paulus/Handler/Exception/RestfulExceptionHandler.php
+++ b/src/Paulus/Handler/Exception/RestfulExceptionHandler.php
@@ -125,8 +125,15 @@ class RestfulExceptionHandler extends InformativeExceptionHandler
     {
         $this->logInfoMessage();
 
+        $log_level = LogLevel::ERROR;
+
+        // If the API exception is representing a server error
+        if (500 <= $exception->getCode() && $exception->getCode() <= 599) {
+            $log_level = LogLevel::CRITICAL;
+        }
+
         // Write to our log
-        $this->logger->error($exception->getMessage(), ['exception' => $exception]);
+        $this->logger->log($log_level, $exception->getMessage(), ['exception' => $exception]);
 
         $more_info = null;
 


### PR DESCRIPTION
This PR is tiny.

Essentially it changes the `RestfulExceptionHandler` to log server errors at the "critical" log level, instead of logging all API exceptions at the "error" log level.

This allows an application to quickly grep for all server/database issues much more easily.
:smiley: 
