### PR TITLE
Content-type header check now case insensitive

### DIFF
--- a/src/Paulus/Request/AutomaticParamsParserRequest.php
+++ b/src/Paulus/Request/AutomaticParamsParserRequest.php
@@ -42,7 +42,7 @@ class AutomaticParamsParserRequest extends Request
             || $request->method('DELETE')) {
 
             // Parse Form URL Encoded attributes
-            if (strpos($request->headers()->get('content-type'), 'application/x-www-form-urlencoded') !== false
+            if (stripos($request->headers()->get('content-type'), 'application/x-www-form-urlencoded') !== false
                 && !$request->method('POST')) {
 
                 // Parse the body into a params array
@@ -51,8 +51,8 @@ class AutomaticParamsParserRequest extends Request
                 // Replace the post params with the parse params
                 $request->paramsPost()->replace($params);
 
-            } elseif (strpos($request->headers()->get('content-type'), 'application/json') !== false
-                || strpos($request->headers()->get('content-type'), 'application/x-json') !== false) {
+            } elseif (stripos($request->headers()->get('content-type'), 'application/json') !== false
+                || stripos($request->headers()->get('content-type'), 'application/x-json') !== false) {
 
                 // Decode the JSON body
                 $params = json_decode($request->body(), true);


### PR DESCRIPTION
Thanks to @ccpmark for finding this bug and @mcos for finding the solution.

As stated in [RFC1341](http://www.w3.org/Protocols/rfc1341/4_Content-Type.html):

> The type, subtype, and parameter names are not case sensitive. For example, TEXT, Text, and TeXt are all equivalent.

So `application/JSON` and `ApPlICaTioN/JsOn` etc should be treated as the same during the request.
