### PR TITLE
Docblock Fix

### DIFF
--- a/src/Paulus/Exception/Http/ApiExceptionTrait.php
+++ b/src/Paulus/Exception/Http/ApiExceptionTrait.php
@@ -50,7 +50,7 @@ trait ApiExceptionTrait
      * @param Exception $previous
      * @static
      * @access public
-     * @return ApiExceptionInterface
+     * @return static
      */
     public static function create($message = null, $code = null, Exception $previous = null)
     {


### PR DESCRIPTION
This PR simply changes the `@return` tag in `ApiExceptionTrait::create` to `static` to help improve the ability of dev-tools to infer a more specific return type than just `ApiExceptionInterface`.
