### PR TITLE
Bugfix - Controller exception handling delegation

### DIFF
--- a/src/Paulus/Controller/AbstractController.php
+++ b/src/Paulus/Controller/AbstractController.php
@@ -216,6 +216,8 @@ abstract class AbstractController implements ControllerInterface
 
         // Delegate to our application's exception handler
         $this->app()->getExceptionHandler()->handleException($e);
+
+        return $this;
     }
 
     /**

--- a/src/Paulus/Controller/AbstractController.php
+++ b/src/Paulus/Controller/AbstractController.php
@@ -214,8 +214,8 @@ abstract class AbstractController implements ControllerInterface
             $e = BadGateway::create(null, null, $e);
         }
 
-        // Throw it up the stack. Let someone else handle it
-        throw $e;
+        // Delegate to our application's exception handler
+        $this->app()->getExceptionHandler()->handleException($e);
     }
 
     /**


### PR DESCRIPTION
So @jstruzik was working on a feature when he realized that a task designed to be run by [`fastcgi_finish_request()`](http://php.net/manual/en/function.fastcgi-finish-request.php) was being ignored. I immediately figured that it was maybe a runtime configuration issue or something, but after a quick look into the exception handling stack I realized an issue: [our `AbstractController` exception handler was calling a `throw`](https://github.com/Rican7/Paulus/blob/912233e74c1c8fd1f319fa3c6ec98f2a89581d9e/src/Paulus/Controller/AbstractController.php#L217-L218).

Now, this `AbstractController` exception handling change was originally made as part of #6, since the work done in that PR allowed for the application's exception handler to be registered to the PHP runtime as the "default" exception handler. There's a few issues with using that approach, though, with the most notable being pretty prominent in the [manual's description of the method](http://php.net/set_exception_handler):

> Sets the default exception handler if an exception is not caught within a try/catch block. **Execution will stop after the exception_handler is called.**

Oh. Well, shit.

So, yea, after the exception was being "handled", the runtime was quitting execution of the rest of the application. Not good. Simply changing the call to `throw` into a deliberate call to the application's exception handler fixed the problem. Woot!

Immediately after changing the call, though, I realized all of the other benefits this provides:
The new way of handling is more direct, and foregoes the more magical approach of exception handling by throwing the exception up the call-stack. It also improves code-path detection and readability, as well as testability, as the exception's path of handling is now more explicit, while still behaving in the same manner as before. Finally, this allows us to more properly honor the `ControllerInterface`, by actually returning the expected value as defined by the interface contract.

So, yea. Pretty good for only a single line of behavioral code. :smile: 
