### PR TITLE
Bugfix - PHP 7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,22 @@ php:
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
+    - 7.1
+    - nightly
     - hhvm
 
+matrix:
+    allow_failures:
+        - php: nightly
+        # Remove once more tests are in and we're confident with HHVM compatibility
+        - php: hhvm
+    fast_finish: true
+
 before_script:
-    - composer install --prefer-dist --dev
+    - composer install --prefer-dist
 
 script:
     - composer validate
     - ./vendor/bin/phpunit
     - ./vendor/bin/phpcs --standard=PSR2 --encoding=utf-8 -p src/ tests/
-
-matrix:
-    allow_failures:
-        # Remove once more tests are in and we're confident with HHVM compatibility
-        - php: hhvm
-    fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "require": {
     "php": ">=5.4.0",
-    "klein/klein": "~2.1.0",
+    "klein/klein": "~2.1.1",
     "psr/log": "~1.0"
   },
   "require-dev": {

--- a/src/Paulus/Controller/AbstractController.php
+++ b/src/Paulus/Controller/AbstractController.php
@@ -11,10 +11,10 @@
 
 namespace Paulus\Controller;
 
-use Exception;
 use Klein\AbstractResponse;
 use Klein\Request;
 use Klein\ServiceProvider;
+use PDOException;
 use Paulus\Exception\Http\InvalidParameters;
 use Paulus\Exception\Http\ObjectNotFound;
 use Paulus\Exception\Http\Standard\BadGateway;
@@ -163,12 +163,7 @@ abstract class AbstractController implements ControllerInterface
     }
 
     /**
-     * Handle the result of the route callback called
-     * through the current controller
-     *
-     * @param mixed $result_data    The data to be evaluated and/or filtered
-     * @access public
-     * @return ControllerInterface
+     * {@inheritdoc}
      */
     public function handleResult($result_data)
     {
@@ -200,17 +195,12 @@ abstract class AbstractController implements ControllerInterface
     }
 
     /**
-     * Handle a exception thrown during the callback
-     * execution of the current controller
-     *
-     * @param Exception $e  The exception object that was thrown
-     * @access public
-     * @return ControllerInterface
+     * {@inheritdoc}
      */
-    public function handleException(Exception $e)
+    public function handleException($e)
     {
         // Let's turn PDO database exceptions into 502's
-        if ($e instanceof \PDOException) {
+        if ($e instanceof PDOException) {
             $e = BadGateway::create(null, null, $e);
         }
 

--- a/src/Paulus/Controller/ControllerInterface.php
+++ b/src/Paulus/Controller/ControllerInterface.php
@@ -12,6 +12,7 @@
 namespace Paulus\Controller;
 
 use Exception;
+use Throwable;
 
 /**
  * ControllerInterface
@@ -35,9 +36,12 @@ interface ControllerInterface
      * Handle a exception thrown during the callback
      * execution of the current controller
      *
-     * @param Exception $e  The exception object that was thrown
+     * TODO: Change the `$exception` parameter to type-hint against `Throwable`
+     * once PHP 5.x support is no longer necessary.
+     *
+     * @param Exception|Throwable $e  The exception object that was thrown
      * @access public
      * @return ControllerInterface
      */
-    public function handleException(Exception $e);
+    public function handleException($e);
 }

--- a/src/Paulus/Exception/Http/ApiExceptionFactory.php
+++ b/src/Paulus/Exception/Http/ApiExceptionFactory.php
@@ -22,6 +22,7 @@ use Paulus\Exception\Http\Standard\NotAcceptable;
 use Paulus\Exception\Http\Standard\NotFound;
 use Paulus\Exception\Http\Standard\NotImplemented;
 use Paulus\Exception\Http\Standard\Unauthorized;
+use Throwable;
 
 /**
  * ApiExceptionFactory
@@ -36,35 +37,38 @@ class ApiExceptionFactory
     /**
      * Create an HTTP exception using a HTTP status code.
      *
-     * @param int $code              The HTTP status code
-     * @param string $message        The optional message to include with the exception
-     * @param Exception $previous    The previous exception thrown, if any
+     * TODO: Change the `$previous` parameter to type-hint against `Throwable`
+     * once PHP 5.x support is no longer necessary.
+     *
+     * @param int $code                     The HTTP status code
+     * @param string $message               The optional message to include with the exception
+     * @param Exception|Throwable $previous The previous exception thrown, if any
      * @static
      * @access public
      * @return ApiExceptionInterface
      */
-    public static function createFromCode($code, $message = null, Exception $exception = null)
+    public static function createFromCode($code, $message = null, $previous = null)
     {
         switch ($code) {
             case 400:
-                return BadRequest::create($message, $code, $exception);
+                return BadRequest::create($message, $code, $previous);
             case 401:
-                return Unauthorized::create($message, $code, $exception);
+                return Unauthorized::create($message, $code, $previous);
             case 403:
-                return Forbidden::create($message, $code, $exception);
+                return Forbidden::create($message, $code, $previous);
             case 404:
-                return NotFound::create($message, $code, $exception);
+                return NotFound::create($message, $code, $previous);
             case 405:
-                return MethodNotAllowed::create($message, $code, $exception);
+                return MethodNotAllowed::create($message, $code, $previous);
             case 406:
-                return NotAcceptable::create($message, $code, $exception);
+                return NotAcceptable::create($message, $code, $previous);
             case 501:
-                return NotImplemented::create($message, $code, $exception);
+                return NotImplemented::create($message, $code, $previous);
             case 502:
-                return BadGateway::create($message, $code, $exception);
+                return BadGateway::create($message, $code, $previous);
             case 500:
             default:
-                return InternalServerError::create($message, null, $exception);
+                return InternalServerError::create($message, null, $previous);
         }
     }
 }

--- a/src/Paulus/Exception/Http/ApiExceptionInterface.php
+++ b/src/Paulus/Exception/Http/ApiExceptionInterface.php
@@ -13,6 +13,7 @@ namespace Paulus\Exception\Http;
 
 use Exception;
 use Paulus\Exception\PaulusExceptionInterface;
+use Throwable;
 
 /**
  * ApiExceptionInterface
@@ -30,14 +31,17 @@ interface ApiExceptionInterface extends PaulusExceptionInterface
      * Static creation method designed to allow for easier fall-back to default
      * values than the default exception constructor
      *
+     * TODO: Change the `$previous` parameter to type-hint against `Throwable`
+     * once PHP 5.x support is no longer necessary.
+     *
      * @param string $message
      * @param int $code
-     * @param Exception $previous
+     * @param Exception|Throwable $previous
      * @static
      * @access public
      * @return ApiExceptionInterface
      */
-    public static function create($message = null, $code = null, Exception $previous = null);
+    public static function create($message = null, $code = null, $previous = null);
 
     /**
      * Get the default message for this type of exception

--- a/src/Paulus/Exception/Http/ApiExceptionTrait.php
+++ b/src/Paulus/Exception/Http/ApiExceptionTrait.php
@@ -12,6 +12,7 @@
 namespace Paulus\Exception\Http;
 
 use Exception;
+use Throwable;
 
 /**
  * ApiExceptionTrait
@@ -45,14 +46,17 @@ trait ApiExceptionTrait
      * Static creation method designed to allow for easier fall-back to default
      * values than the default exception constructor
      *
+     * TODO: Change the `$previous` parameter to type-hint against `Throwable`
+     * once PHP 5.x support is no longer necessary.
+     *
      * @param string $message
      * @param int $code
-     * @param Exception $previous
+     * @param Exception|Throwable $previous
      * @static
      * @access public
      * @return static
      */
-    public static function create($message = null, $code = null, Exception $previous = null)
+    public static function create($message = null, $code = null, $previous = null)
     {
         $message = (null !== $message) ? $message : static::getDefaultMessage();
         $code = (null !== $code) ? $code : static::getDefaultCode();

--- a/src/Paulus/Handler/Exception/BasicExceptionHandler.php
+++ b/src/Paulus/Handler/Exception/BasicExceptionHandler.php
@@ -11,7 +11,6 @@
 
 namespace Paulus\Handler\Exception;
 
-use Exception;
 use Klein\AbstractResponse;
 use Paulus\Response\ApiResponse;
 use Psr\Log\LoggerInterface;
@@ -102,13 +101,9 @@ class BasicExceptionHandler implements ExceptionResponseHandlerInterface
     }
 
     /**
-     * Handle an exception thrown in the application
-     *
-     * @param Exception $exception
-     * @access public
-     * @return boolean
+     * {@inheritdoc}
      */
-    public function handleException(Exception $exception)
+    public function handleException($exception)
     {
         $this->logInfoMessage();
 

--- a/src/Paulus/Handler/Exception/ExceptionHandlerInterface.php
+++ b/src/Paulus/Handler/Exception/ExceptionHandlerInterface.php
@@ -12,6 +12,7 @@
 namespace Paulus\Handler\Exception;
 
 use Exception;
+use Throwable;
 
 /**
  * ExceptionHandlerInterface
@@ -26,9 +27,12 @@ interface ExceptionHandlerInterface
     /**
      * Handle an exception thrown in the application
      *
-     * @param Exception $exception
+     * TODO: Change the `$exception` parameter to type-hint against `Throwable`
+     * once PHP 5.x support is no longer necessary.
+     *
+     * @param Exception|Throwable $exception
      * @access public
      * @return boolean
      */
-    public function handleException(Exception $exception);
+    public function handleException($exception);
 }

--- a/src/Paulus/Handler/Exception/InformativeExceptionHandler.php
+++ b/src/Paulus/Handler/Exception/InformativeExceptionHandler.php
@@ -11,7 +11,6 @@
 
 namespace Paulus\Handler\Exception;
 
-use Exception;
 use Paulus\Response\ApiResponse;
 
 /**
@@ -62,13 +61,9 @@ class InformativeExceptionHandler extends BasicExceptionHandler
      */
 
     /**
-     * Handle an exception thrown in the application
-     *
-     * @param Exception $exception
-     * @access public
-     * @return boolean
+     * {@inheritdoc}
      */
-    public function handleException(Exception $exception)
+    public function handleException($exception)
     {
         // Prepare our error response
         $this->prepareErrorResponse(

--- a/src/Paulus/Handler/Exception/RestfulExceptionHandler.php
+++ b/src/Paulus/Handler/Exception/RestfulExceptionHandler.php
@@ -11,7 +11,6 @@
 
 namespace Paulus\Handler\Exception;
 
-use Exception;
 use Klein\AbstractResponse;
 use Klein\HttpStatus;
 use Paulus\Exception\Http\ApiExceptionInterface;
@@ -93,13 +92,9 @@ class RestfulExceptionHandler extends InformativeExceptionHandler
     }
 
     /**
-     * Handle an exception thrown in the application
-     *
-     * @param Exception $exception
-     * @access public
-     * @return boolean
+     * {@inheritdoc}
      */
-    public function handleException(Exception $exception)
+    public function handleException($exception)
     {
         // Handle our RESTful exceptions
         if ($exception instanceof ApiExceptionInterface) {

--- a/src/Paulus/Paulus.php
+++ b/src/Paulus/Paulus.php
@@ -12,7 +12,6 @@
 namespace Paulus;
 
 use BadMethodCallException;
-use Exception;
 use Klein\AbstractResponse;
 use Klein\Response;
 use LogicException;
@@ -341,7 +340,7 @@ class Paulus
     {
         // Register an error handler through our router's catcher
         $this->router->onError(
-            function ($router, $message, $class, Exception $exception) {
+            function ($router, $message, $class, $exception) {
 
                 // Check if we have a callable handler in our controller
                 $callable = $router->getControllerExceptionHandler();

--- a/tests/Paulus/Tests/Response/ApiResponseTest.php
+++ b/tests/Paulus/Tests/Response/ApiResponseTest.php
@@ -61,9 +61,9 @@ class ApiResponseTest extends AbstractPaulusTest
         $this->assertFalse($response->isLocked());
 
         $this->assertEquals(
-            array_change_key_case($test_headers, CASE_LOWER),
+            $test_headers,
             $response->headers()->all(
-                array_keys(array_change_key_case($test_headers, CASE_LOWER))
+                array_keys($test_headers)
             )
         );
     }

--- a/tests/Paulus/Tests/Response/JsonResponseTest.php
+++ b/tests/Paulus/Tests/Response/JsonResponseTest.php
@@ -61,9 +61,9 @@ class JsonResponseTest extends AbstractPaulusTest
         $this->assertFalse($response->isLocked());
 
         $this->assertEquals(
-            array_change_key_case($test_headers, CASE_LOWER),
+            $test_headers,
             $response->headers()->all(
-                array_keys(array_change_key_case($test_headers, CASE_LOWER))
+                array_keys($test_headers)
             )
         );
     }
@@ -107,8 +107,8 @@ class JsonResponseTest extends AbstractPaulusTest
         );
 
         $this->assertEquals(
-            array_change_key_case($test_headers, CASE_LOWER),
-            array_change_key_case($response->headers()->all(), CASE_LOWER)
+            $test_headers,
+            $response->headers()->all()
         );
     }
 }


### PR DESCRIPTION
This PR updates Paulus to be code-compatible with PHP 7 and updates some tests to play a bit nicer with the [Klein v2.1.1](https://github.com/klein/klein.php/releases/tag/v2.1.1) release.

[Exception handling is one of the biggest backwards-incompatible changes made in the major release of PHP 7](http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.error-handling), and due to the fact that the Paulus framework works with exceptions at it's core, this was the biggest change necessary to make Paulus work with PHP 7.

This PR _should_ enable full PHP 7 compatibility, but it'll be hard to say without integration testing.